### PR TITLE
Fix missing assets file check

### DIFF
--- a/src/FileClasses/FileManager.cpp
+++ b/src/FileClasses/FileManager.cpp
@@ -155,7 +155,7 @@ std::vector<std::filesystem::path> PakFileConfiguration::getMissingFiles(const C
         const auto path =
             cache.find(std::u8string{reinterpret_cast<const char8_t*>(fileName.c_str()), fileName.size()});
         if (!path.has_value())
-            missing.emplace_back(path.value());
+            missing.emplace_back(fileName);
     }
 
     return missing;


### PR DESCRIPTION
Fix a logic typo in missing assets file check to avoid an unhandled `std::bad_optional_access` exception when data files are missing. Fixes the proper asset diagnostics dialog to show up.

Before:

![image](https://user-images.githubusercontent.com/225351/172054144-9e7ce207-19f3-4543-8bf5-799cadf18686.png)

![image](https://user-images.githubusercontent.com/225351/172054147-e7fa3220-8770-486f-b245-788e2ea3cfad.png)

After:

![image](https://user-images.githubusercontent.com/225351/172054153-084ed3db-ead1-446f-91d6-5b50cd9af4d9.png)
