### PR TITLE
Fix an exception being thrown from NetworkManager::getMaxPeerRoundTripTime()

### DIFF
--- a/src/Network/NetworkManager.cpp
+++ b/src/Network/NetworkManager.cpp
@@ -781,6 +781,8 @@ std::vector<std::string> NetworkManager::getConnectedPeers() const {
 }
 
 int NetworkManager::getMaxPeerRoundTripTime() const {
+    if (peerList_.empty())
+        return 1; // No peers - RTT is not meaningful.
     const auto max_rtt =
         std::ranges::max(peerList_, {}, [](const auto* const p) { return p->roundTripTime; })->roundTripTime;
 


### PR DESCRIPTION
Fix an exception being thrown from NetworkManager::getMaxPeerRoundTripTime() when no peers are connected in multiplayer game setup menu.