### PR TITLE
Fix an issue with wrong mouse clicks registering in Mentat screen

### DIFF
--- a/include/GUI/Container.h
+++ b/include/GUI/Container.h
@@ -103,7 +103,9 @@ public:
 
         for (const auto& widgetData : containedWidgets) {
             const Point pos = getPosition(widgetData);
-            bWidgetFound |= widgetData.pWidget->handleMouseLeft(x - pos.x, y - pos.y, pressed);
+            if (widgetData.pWidget->isEnabled() && widgetData.pWidget->isVisible()) {
+                bWidgetFound |= widgetData.pWidget->handleMouseLeft(x - pos.x, y - pos.y, pressed);
+            }
         }
 
         return bWidgetFound;


### PR DESCRIPTION
Fix an issue where mouse clicking in the Mentat help screen would activate a different Mentat help item while one was already active.

Bug STR:

1. Open the ingame Mentat help screen.
2. Click on one of the help items, e.g. `"House Atreides"`. However before clicking on the item, make a note where another menu item, e.g. `"House Harkonnen"` is located.

![image](https://user-images.githubusercontent.com/225351/172443586-ea36d070-c4c5-4877-93ec-89c6cdf6a644.png)

3. After clicking `"House Atreides"`, its help screen shows up:

![image](https://user-images.githubusercontent.com/225351/172444350-5fb96b8a-077f-4a8a-b655-a5dbcf9fe53c.png)

4. Now while this screen is being displayed, move the mouse cursor to where the `"House Harkonnen"` item was located in previous screen and click there.

Observed: The Mentat info screen will now jump to showing the help from the `"House Harkonnen"` item without finishing the text elements from the previously activated `"House Atreides"` section:

![image](https://user-images.githubusercontent.com/225351/172444490-6bcf28a6-29e0-4042-8cd6-25df354da385.png)

It looks like the intention of this code was to disable the mentat item list when one of those items is clicked on:

https://github.com/henricj/dunelegacy/blob/568c317007a82eb140bd08f8ace09bccaf6bfe90/src/Menu/MentatHelp.cpp#L184-L185

However that would disable only the Container element, but the children of this container would still remain visible and active, and each get tested for mouse interaction.

This fix assumes a **hereditary property** for `isEnabled` and `isVisible`: if a parent item is disabled (or hidden), then all the (grand)children of that UI element will also be disabled (or hidden). This feels like a sensible assumption and it does fix the Mentat screen, although I don't have a 100% proof whether this assumption holds in all UIs of the game.
