### PR TITLE
Fix an issue with sandworms being always instantiated to HOUSE_HARKONNEN.

### DIFF
--- a/src/INIMap/INIMapLoader.cpp
+++ b/src/INIMap/INIMapLoader.cpp
@@ -1034,9 +1034,9 @@ House* INIMapLoader::getOrCreateHouse(const GameContext& context, HOUSETYPE hous
 HOUSETYPE INIMapLoader::getHouseID(std::string_view name) {
     const auto lowerName = strToLower(name);
 
-    if (!housename2house.empty()) {
-        return housename2house[lowerName];
-    }
+    const auto it = housename2house.find(lowerName);
+    if (it != housename2house.end())
+        return it->second;
 
     return getHouseByName(lowerName);
 }


### PR DESCRIPTION
Fixes #29.

Before this change, Sand worms would be created to HOUSE_HARKONNEN.

After this change, Sand worms are created to HOUSE_FREMEN like the .ini assets suggest, e.g.

```
ID016=Fremen,Sandworm,256,2641,64,Ambush
ID017=Fremen,Sandworm,256,2210,64,Ambush
```

Before Fremen would be associated with HOUSE_HARKONNEN:

![image](https://user-images.githubusercontent.com/225351/172607666-94fefbce-19d9-4d77-8e4e-454ea76c084e.png)

Afterwards, Sand worms are instantiated to HOUSE_FREMEN:

![image](https://user-images.githubusercontent.com/225351/172607779-35a8e308-3360-4765-9629-a014cfce0a5f.png)

With some luck, this might also fix issue #15.

It might also fix the issue that on my playthroughs of each of Harkonnen, Ordos and Atreides, I never saw any Sardaukar dropship troops during the game. I recall that during the campaign in later levels, the Emperor should be supplying the enemy with some Sardaukar troops, but that never happened.
