### PR TITLE
Remove use of relying on exceptions as control flow when reading an input stream

### DIFF
--- a/include/Network/ENetPacketIStream.h
+++ b/include/Network/ENetPacketIStream.h
@@ -39,6 +39,8 @@ public:
         }
     }
 
+    long bytesLeft() const override { return packet->dataLength - currentPos; }
+
     ENetPacketIStream& operator=(const ENetPacketIStream& p) {
         if (this != &p) {
             ENetPacket* packetCopy = enet_packet_create(p.packet->data, p.packet->dataLength, p.packet->flags);

--- a/include/misc/IFileStream.h
+++ b/include/misc/IFileStream.h
@@ -40,8 +40,12 @@ public:
     bool readBool() override;
     float readFloat() override;
 
+    long bytesLeft() const override { return sizeBytes_ - bytePos_; }
+
 private:
     FILE* fp;
+    long sizeBytes_;
+    long bytePos_;
 };
 
 #endif // IFILESTREAM_H

--- a/include/misc/IMemoryStream.h
+++ b/include/misc/IMemoryStream.h
@@ -52,6 +52,8 @@ public:
 
     float readFloat() override;
 
+    long bytesLeft() const override { return bufferSize - currentPos; }
+
 private:
     size_t currentPos{};
     size_t bufferSize{};

--- a/include/misc/InputStream.h
+++ b/include/misc/InputStream.h
@@ -47,6 +47,10 @@ public:
     virtual bool readBool()       = 0;
     virtual float readFloat()     = 0;
 
+    // Returns the number of bytes available in the stream before EOF.
+    // Attempting to read more than this many bytes will throw an EOF exception.
+    virtual long bytesLeft() const = 0;
+
     /**
         Reads in a Sint8 value.
         \return the read value

--- a/src/CommandManager.cpp
+++ b/src/CommandManager.cpp
@@ -59,11 +59,13 @@ void CommandManager::save(OutputStream& stream) const {
 
 void CommandManager::load(InputStream& stream) {
     try {
-        while (true) {
+        while (stream.bytesLeft() > 0) {
             const auto cycle = stream.readUint32();
             addCommand(Command{stream}, cycle);
         }
-    } catch (InputStream::exception&) { }
+    } catch (InputStream::exception& e) {
+        sdl2::log_info("Warning: Unexpected input stream exception in CommandManager::load: %s", e.what());
+    }
 }
 
 void CommandManager::update() {

--- a/src/misc/IFileStream.cpp
+++ b/src/misc/IFileStream.cpp
@@ -30,7 +30,7 @@
 #    include <Windows.h>
 #endif
 
-IFileStream::IFileStream() : fp(nullptr) { }
+IFileStream::IFileStream() : fp(nullptr), sizeBytes_(0), bytePos_(0) { }
 
 IFileStream::~IFileStream() {
     close();
@@ -47,13 +47,20 @@ bool IFileStream::open(const std::filesystem::path& filename) {
     fp = fopen(normal.c_str(), "rb");
 #endif
 
+    fseek(fp, 0, SEEK_END);
+    sizeBytes_ = ftell(fp);
+    fseek(fp, 0, SEEK_SET);
+    bytePos_ = 0;
+
     return fp != nullptr;
 }
 
 void IFileStream::close() {
     if (fp != nullptr) {
         fclose(fp);
-        fp = nullptr;
+        fp         = nullptr;
+        sizeBytes_ = 0;
+        bytePos_   = 0;
     }
 }
 
@@ -76,6 +83,8 @@ std::string IFileStream::readString() {
         THROW(InputStream::error, "IFileStream::readString(): An I/O-Error occurred!");
     }
 
+    bytePos_ += length;
+
     return str;
 }
 
@@ -87,6 +96,8 @@ uint8_t IFileStream::readUint8() {
         }
         THROW(InputStream::error, "IFileStream::readUint8(): An I/O-Error occurred!");
     }
+
+    bytePos_ += sizeof(uint8_t);
 
     return tmp;
 }
@@ -100,6 +111,8 @@ uint16_t IFileStream::readUint16() {
         THROW(InputStream::error, "IFileStream::readUint16(): An I/O-Error occurred!");
     }
 
+    bytePos_ += sizeof(uint16_t);
+
     return SDL_SwapLE16(tmp);
 }
 
@@ -112,6 +125,8 @@ uint32_t IFileStream::readUint32() {
         THROW(InputStream::error, "IFileStream::readUint32(): An I/O-Error occurred!");
     }
 
+    bytePos_ += sizeof(uint32_t);
+
     return SDL_SwapLE32(tmp);
 }
 
@@ -123,6 +138,9 @@ uint64_t IFileStream::readUint64() {
         }
         THROW(InputStream::error, "IFileStream::readUint64(): An I/O-Error occurred!");
     }
+
+    bytePos_ += sizeof(uint64_t);
+
     return SDL_SwapLE64(tmp);
 }
 


### PR DESCRIPTION
Remove use of relying on exceptions as control flow when reading an input stream. Closes #24.

This eases running the game while having a debugger attached that catches on all thrown exceptions.