### PR TITLE
Fix compilation warning

### DIFF
--- a/include/misc/BufferedReader.h
+++ b/include/misc/BufferedReader.h
@@ -169,7 +169,7 @@ private:
             partial = pending_.size();
         }
 
-        assert(partial < size);
+        assert(size_t(partial) < size);
 
         const auto read_length = size - partial;
 

--- a/src/Map.cpp
+++ b/src/Map.cpp
@@ -692,7 +692,7 @@ Map::BoxOffsets::BoxOffsets(int size, Coord box) {
             set.emplace_back(i, depth + box.y - 1); // Bottom
         }
 
-        assert(border_length == set.size());
+        assert(size_t(border_length) == set.size());
     }
 }
 

--- a/src/Renderer/DuneTextures.cpp
+++ b/src/Renderer/DuneTextures.cpp
@@ -268,7 +268,7 @@ public:
     }
 
     void add_duplicate(int key, Identifier identifier) {
-        assert(key >= 0 && key < surfaces_.size());
+        assert(key >= 0 && size_t(key) < surfaces_.size());
 
         duplicates_.emplace_back(key, identifier);
     }


### PR DESCRIPTION
Very tiny improvement by fixing warnings issued by g++ 11.2.0 on Linux ubuntu 22.04 LTS